### PR TITLE
sort rows into default view

### DIFF
--- a/src/component/DataTable.js
+++ b/src/component/DataTable.js
@@ -1,5 +1,4 @@
 import React, { useMemo } from 'react';
-import { useTable } from 'react-table';
 import MUITable from './MUITable';
 
 function getColumns() {
@@ -54,13 +53,15 @@ function filterEmpty(str) {
 
 function createRows(organizations) {
   const data = Object.entries(organizations);
-  return data.map(([slug, item]) => ({
+  const formattedData = data.map(([slug, item]) => ({
     slug,
     charity: filterEmpty(item['Full Name']),
     cause: filterEmpty(item['Core Cause']),
     totalDonations: filterEmpty(item['Total Donations']),
     gwwcDonations: filterEmpty(item['GWWC &dollar donated']),
+    defaultSort: item['Default Sort'],
   })).filter(x => !!x['charity']);
+  return formattedData.sort((a, b) => (a.defaultSort > b.defaultSort) ? 1 : -1)
 }
 
 function DataTable(props) {


### PR DESCRIPTION
This will sort the rows in the table into the default view we want, if the Default View column in the sheet is a number corresponding to the rank we want that row to have. 

I had trouble getting the data into firebase, though -- I put the data into the google sheet, but it's showing up in Firebase as `&null` and from the execution logs I'm pretty sure it's a permissions issue since I'm not the owner of the google sheet.

@mitrafantos would you be able to look into the issue getting the google sheet data into firebase? After that's taken care of, I think we can merge this and we should be good with the default view.